### PR TITLE
Add room joining infrastructure, along with firebase cleanup hooks

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -5,12 +5,7 @@ export default Ember.Controller.extend({
 
   actions: {
     submit: function() {
-      // TODO Make a fail-safe createRecord query by verifying if a record for
-      // the given room already exists
-      this.store.createRecord('room', {
-        id: this.get('room'),
-        users: [this.get('application.model')],
-      }).save();
+      this.transitionToRoute('room', this.get('room'));
     },
   },
 });

--- a/app/models/room.js
+++ b/app/models/room.js
@@ -1,5 +1,5 @@
 import DS from 'ember-data';
 
 export default DS.Model.extend({
-  users: DS.hasMany('user'),
+  users: DS.hasMany('user', {async: true}),
 });

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  model: function(model) {
+  model: function() {
     // assigning the username to a random string for now
     let username = Math.random().toString(32).split('.')[1];
 
@@ -10,6 +10,10 @@ export default Ember.Route.extend({
       id: username,
       username: username,
     });
+
+    // Remove this user when firebase connection is over
+    user.ref().onDisconnect().remove();
+    // Push the new user to firebase
     user.save();
 
     return user;

--- a/app/routes/room.js
+++ b/app/routes/room.js
@@ -1,7 +1,27 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  model: function(model) {
-    return this.store.findRecord('room', model.room);
+  model: function(url) {
+    let user = this.modelFor('application');
+
+    let room = this.store.findRecord('room', url.room).then(room => {
+      // If the room instance was found at firebase, add oneself to the users
+      room.get('users').addObject(user);
+      // remember to remove the user when the connection is over
+      room.ref().child('users').child(user.id).onDisconnect().remove();
+      room.save();
+    }, () => {
+      // If no instance was found, create one.
+      room = this.store.createRecord('room', {
+        id: url.room,
+        users: [user],
+      });
+      // remember to clean-up the user when the connection is over
+      room.ref().child('users').child(user.id).onDisconnect().remove();
+
+      room.save();
+    });
+
+    return room;
   },
 });


### PR DESCRIPTION
The proposed changes are available at http://nihey.github.io/EnGageRTC/
To properly verify the firebase changes you should refer to https://fiery-fire-6672.firebaseio.com/

Everything that was added to the previous changes is listed below:

- More users are able to join a room

![rsz_screenshot_from_2015-11-17_091537](https://cloud.githubusercontent.com/assets/5278570/11210134/02bd8390-8d0d-11e5-84e2-1eb40825afc9.png)

- Users can join rooms directly via url:
  - entering http://nihey.github.io/EnGageRTC/foobar will automatically join you to the `foobar` room

- Users and rooms are cleansed once users are disconnected
![rsz_screenshot_from_2015-11-17_091551](https://cloud.githubusercontent.com/assets/5278570/11210442/4f9aa2ae-8d0f-11e5-816f-7f2ae5ea5f37.png)

With this, it is finally possible to easily access the `users` in a `room` array from `ember-data`.

About merging this PR intro a `develop` branch, I currently can't. The `develop` branch it should be firstly created on the source repo, but I have no rights to do this.